### PR TITLE
Dark mode toggle fix

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -72,6 +72,12 @@ export default function Layout({ title, description, children }) {
     Cookies.remove('cartItems');
     router.push('/');
   };
+
+  useEffect(() => {
+    const colorMode = Cookies.get('darkMode');
+    dispatch({ type:colorMode === 'OFF' ? 'DARK_MODE_OFF' : 'DARK_MODE_ON'  });
+  }, [dispatch]);
+  
   return (
     <div>
       <Head>


### PR DESCRIPTION
Added a useEffect hook to prevent darkMode toggle switch from switching to off state after a browser refresh when dark mode is enabled by user.